### PR TITLE
Upgrading Pydantic version

### DIFF
--- a/KeyCrm/types/base.py
+++ b/KeyCrm/types/base.py
@@ -1,10 +1,9 @@
 from pydantic import BaseModel, HttpUrl
-from pydantic.generics import GenericModel
 from typing import List, Optional, Any, TypeVar, Generic, Iterator
 
 ItemType = TypeVar('ItemType')
 
-class ListResponse(GenericModel, Generic[ItemType]):
+class ListResponse(BaseModel, Generic[ItemType]):
     """
     Represents a List response.
     """

--- a/KeyCrm/webhook/types/order.py
+++ b/KeyCrm/webhook/types/order.py
@@ -42,5 +42,5 @@ class OrderStatusChangeContext(BaseModel):
     has_reserves: bool
 
 class OrderStatusChangeEvent(BaseEvent):
-    event = "order.change_order_status"
+    event: str = "order.change_order_status"
     context: OrderStatusChangeContext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "requests ~= 2.30.0",
-    "pydantic ~= 1.10.7"
+    "pydantic ~= 2.8.2"
 ]
 
 #[project.optional-dependencies]


### PR DESCRIPTION
**Будь ласка, не зливайте ці зміни у мастер гілку до узгодження, можливо ці зміни треба створити окремою гілкою**

Для проекту потребується оновити версію Pydantic до 2.8.2, після чого виникають помилки у пакеті KeyCrmApi, так як він працює на версії Pydantic 1.10.7.

Що було виправлено для підтримки нової версії Pydantic:
- помилка: raise PydanticUserError(
pydantic.errors.PydanticUserError: Field 'event' defined on a base class was overridden by a non-annotated attribute. All field definitions, including overrides, require a type annotation.
https://errors.pydantic.dev/2.8/u/model-field-overridden
- попередження: UserWarning: `pydantic.generics:GenericModel` has been moved to `pydantic.BaseModel`.
  warnings.warn(f'`{import_path}` has been moved to `{new_location}`.')